### PR TITLE
Cast `left/right` to the type of `x` and recycle to the size of `x`

### DIFF
--- a/R/between.R
+++ b/R/between.R
@@ -1,13 +1,16 @@
 #' Find all values within a range
 #'
-#' This is a shortcut for `x >= left & x <= right`,
+#' This is essentially a shortcut for `x >= left & x <= right`, but it also
+#' retains the size of `x` and casts both `left` and `right` to the type of
+#' `x` before making the comparison.
 #'
-#' @param x A vector of values
-#' @param left,right Boundary values.
-#' @param bounds One of \verb{[]}, \verb{[)}, \verb{()}, or `()`, which defines whether the
-#'   boundary is inclusive (`[` / `]`) or exclusive (`(` / `)`).
-#' @return A logical vector. The length will be determined by the common
-#'   length of `x`, `left`, and `right`.
+#' @param x A vector
+#' @param left,right Boundary values. Both `left` and `right` are recycled to
+#'   the size of `x` and are cast to the type of `x`.
+#' @param bounds One of \verb{"[]"}, \verb{"[)"}, \verb{"(]"}, or \verb{"()"},
+#'   which defines whether the boundary is inclusive (with `[` or `]`) or
+#'   exclusive (with `(` or `)`).
+#' @return A logical vector the same size as `x`.
 #' @export
 #' @examples
 #' between(c(1:10, NA), 4, 6)
@@ -16,14 +19,40 @@
 #' today <- Sys.Date()
 #' between(today, today - 1, today + 1)
 between <- function(x, left, right, bounds = "[]") {
+  args <- list(left = left, right = right)
+  args <- vec_cast_common(!!!args, .to = x)
+  args <- vec_recycle_common(!!!args, .size = vec_size(x))
+  left <- args[[1L]]
+  right <- args[[2L]]
+
+  bounds <- check_bounds(bounds)
   bounds <- switch(bounds,
     "[]" = list(`>=`, `<=`),
     "[)" = list(`>=`, `<`),
     "(]" = list(`>`, `<=`),
     "()" = list(`>`, `<`),
-    abort("Unknown `bounds` specification.")
+    abort("Unknown `bounds` specification.", .internal = TRUE)
   )
 
-  bounds[[1]](vec_compare(x, left), 0) &
-    bounds[[2]](vec_compare(x, right), 0)
+  fn_left <- bounds[[1L]]
+  fn_right <- bounds[[2L]]
+
+  left <- vec_compare(x, left)
+  left <- fn_left(left, 0L)
+
+  right <- vec_compare(x, right)
+  right <- fn_right(right, 0L)
+
+  left & right
+}
+
+check_bounds <- function(bounds, ..., error_call = caller_env()) {
+  check_dots_empty0(...)
+
+  arg_match0(
+    arg = bounds,
+    values = c("[]", "[)", "(]", "()"),
+    arg_nm = "bounds",
+    error_call = error_call
+  )
 }

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -7,19 +7,22 @@
 between(x, left, right, bounds = "[]")
 }
 \arguments{
-\item{x}{A vector of values}
+\item{x}{A vector}
 
-\item{left, right}{Boundary values.}
+\item{left, right}{Boundary values. Both \code{left} and \code{right} are recycled to
+the size of \code{x} and are cast to the type of \code{x}.}
 
-\item{bounds}{One of \verb{[]}, \verb{[)}, \verb{()}, or \verb{()}, which defines whether the
-boundary is inclusive (\code{[} / \verb{]}) or exclusive (\code{(} / \verb{)}).}
+\item{bounds}{One of \verb{"[]"}, \verb{"[)"}, \verb{"(]"}, or \verb{"()"},
+which defines whether the boundary is inclusive (with \code{[} or \verb{]}) or
+exclusive (with \code{(} or \verb{)}).}
 }
 \value{
-A logical vector. The length will be determined by the common
-length of \code{x}, \code{left}, and \code{right}.
+A logical vector the same size as \code{x}.
 }
 \description{
-This is a shortcut for \code{x >= left & x <= right},
+This is essentially a shortcut for \code{x >= left & x <= right}, but it also
+retains the size of \code{x} and casts both \code{left} and \code{right} to the type of
+\code{x} before making the comparison.
 }
 \examples{
 between(c(1:10, NA), 4, 6)

--- a/tests/testthat/_snaps/between.md
+++ b/tests/testthat/_snaps/between.md
@@ -1,8 +1,47 @@
-# between() errors
+# casts `left` and `right` to the type of `x` (#74)
+
+    Code
+      between(1L, 1.5, 2L)
+    Condition
+      Error in `between()`:
+      ! Can't convert from `left` <double> to <integer> due to loss of precision.
+      * Locations: 1
+
+---
+
+    Code
+      between(1L, 1L, 2.5)
+    Condition
+      Error in `between()`:
+      ! Can't convert from `right` <double> to <integer> due to loss of precision.
+      * Locations: 1
+
+# recycles `left` and `right` to the size of `x` (#74)
+
+    Code
+      between(1:3, 1:2, 1L)
+    Condition
+      Error in `between()`:
+      ! Can't recycle `left` (size 2) to size 3.
+
+---
+
+    Code
+      between(1:3, 1L, 1:2)
+    Condition
+      Error in `between()`:
+      ! Can't recycle `right` (size 2) to size 3.
+
+# validates `bounds`
 
     Code
       between(1:2, 1, 1, bounds = "")
     Condition
       Error in `between()`:
-      ! Unknown `bounds` specification.
+      ! `bounds` must be one of "[]", "[)", "(]", or "()", not "".
+    Code
+      between(1:2, 1, 1, bounds = 1)
+    Condition
+      Error in `arg_match0()`:
+      ! `bounds` must be a string or character vector.
 

--- a/tests/testthat/test-between.R
+++ b/tests/testthat/test-between.R
@@ -5,8 +5,39 @@ test_that("respects bounds", {
   expect_equal(between(1:2, 1, 2, bounds = "()"), c(FALSE, FALSE))
 })
 
-test_that("between() errors", {
+test_that("casts `left` and `right` to the type of `x` (#74)", {
+  expect_snapshot(error = TRUE, {
+    between(1L, 1.5, 2L)
+  })
+  expect_snapshot(error = TRUE, {
+    between(1L, 1L, 2.5)
+  })
+})
+
+test_that("recycles `left` and `right` to the size of `x` (#74)", {
+  expect_snapshot(error = TRUE, {
+    between(1:3, 1:2, 1L)
+  })
+  expect_snapshot(error = TRUE, {
+    between(1:3, 1L, 1:2)
+  })
+})
+
+test_that("propagates missing values in any input", {
+  na <- NA_integer_
+  expect_identical(between(na, 1L, 2L), NA)
+  expect_identical(between(1L, na, 2L), NA)
+  expect_identical(between(1L, 1L, na), NA)
+})
+
+test_that("can be vectorized along `left` and `right`", {
+  expect_identical(between(1:2, c(0L, 4L), 5L), c(TRUE, FALSE))
+  expect_identical(between(1:2, 0L, c(0L, 3L)), c(FALSE, TRUE))
+})
+
+test_that("validates `bounds`", {
   expect_snapshot(error = TRUE, {
     between(1:2, 1, 1, bounds = "")
+    between(1:2, 1, 1, bounds = 1)
   })
 })


### PR DESCRIPTION
Closes #74 

I've decided that `between(1:5, 1.5, 2.5)` is a code smell, and _should_ be an error (you probably know that column is integer-like, so why are you comparing with fractional values?). So casting to the type of `x` feels correct here. This is different from `between(1:5, 1, 3)`, which should (and does) work fine.

- Casts `left/right` to type of `x`
- Recycles `left/right` to size of `x` (for size stability)
- Added more tests
- Fleshed out docs a bit more
- More holistic checking of `bounds`

The C++ dplyr version is obviously faster, but we get so much out of having a vctrs backed version that I'd say that it is worth it to switch. We can always add `vctrs::vec_between()` later on, and there are obvious places where performance could be improved at the C level

``` r
set.seed(123)
x <- base::sample(1e6)
left <- 5L
right <- 20000L

bench::mark(
  funs::between(x, left, right),
  dplyr::between(x, left, right)
)
#> # A tibble: 2 × 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 funs::between(x, left, right)   32.27ms  33.35ms      30.0      27MB    210. 
#> 2 dplyr::between(x, left, right)   4.81ms   5.35ms     172.     20.4MB     63.9
```

<sup>Created on 2022-05-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>