### PR TITLE
Require dots to be empty in `between()`

### DIFF
--- a/R/between.R
+++ b/R/between.R
@@ -1,4 +1,4 @@
-#' Find all values within a range
+#' Detect if values fall within a range
 #'
 #' This is essentially a shortcut for `x >= left & x <= right`, but it also
 #' retains the size of `x` and casts both `left` and `right` to the type of

--- a/R/between.R
+++ b/R/between.R
@@ -4,6 +4,8 @@
 #' retains the size of `x` and casts both `left` and `right` to the type of
 #' `x` before making the comparison.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x A vector
 #' @param left,right Boundary values. Both `left` and `right` are recycled to
 #'   the size of `x` and are cast to the type of `x`.
@@ -18,7 +20,9 @@
 #'
 #' today <- Sys.Date()
 #' between(today, today - 1, today + 1)
-between <- function(x, left, right, bounds = "[]") {
+between <- function(x, left, right, ..., bounds = "[]") {
+  check_dots_empty0(...)
+
   args <- list(left = left, right = right)
   args <- vec_cast_common(!!!args, .to = x)
   args <- vec_recycle_common(!!!args, .size = vec_size(x))

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/between.R
 \name{between}
 \alias{between}
-\title{Find all values within a range}
+\title{Detect if values fall within a range}
 \usage{
 between(x, left, right, ..., bounds = "[]")
 }

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -4,13 +4,15 @@
 \alias{between}
 \title{Find all values within a range}
 \usage{
-between(x, left, right, bounds = "[]")
+between(x, left, right, ..., bounds = "[]")
 }
 \arguments{
 \item{x}{A vector}
 
 \item{left, right}{Boundary values. Both \code{left} and \code{right} are recycled to
 the size of \code{x} and are cast to the type of \code{x}.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{bounds}{One of \verb{"[]"}, \verb{"[)"}, \verb{"(]"}, or \verb{"()"},
 which defines whether the boundary is inclusive (with \code{[} or \verb{]}) or

--- a/tests/testthat/_snaps/between.md
+++ b/tests/testthat/_snaps/between.md
@@ -45,3 +45,14 @@
       Error in `arg_match0()`:
       ! `bounds` must be a string or character vector.
 
+# dots must be empty
+
+    Code
+      between(1, 0, 1, "[]")
+    Condition
+      Error in `between()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = "[]"
+      i Did you forget to name an argument?
+

--- a/tests/testthat/test-between.R
+++ b/tests/testthat/test-between.R
@@ -41,3 +41,9 @@ test_that("validates `bounds`", {
     between(1:2, 1, 1, bounds = 1)
   })
 })
+
+test_that("dots must be empty", {
+  expect_snapshot(error = TRUE, {
+    between(1, 0, 1, "[]")
+  })
+})


### PR DESCRIPTION
Because `bounds` is an optional argument, and it is much clearer if we require that it be named